### PR TITLE
Remove reference to www.stm32duino.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ## Summary:
 This repo contains the "Hardware" files to support STM32 based boards on Arduino version 1.8.x (some older versions may also work) including [LeafLabs Maple, and Maple mini](http://www.leaflabs.com/about-maple/), and other generic STM32F103 boards.
 
-***PRIMARY SUPPORT FORUM: http://www.stm32duino.com/***
 
 ***We are also on Gitter https://gitter.im/stm32duino/Lobby/***
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/stm32duino/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Hosting of www.stm32duino.com could no be sustained, because traffic and CPU usage breached the AUP on my hosting.

I am unable to continue hosting the forum, and GDPR and other worldwide privacy laws make it impossible for me to give the forum including the data to ST or anyone else.